### PR TITLE
[feat]: Support multiple migrations path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -437,7 +437,7 @@ module.exports = class Umzug extends EventEmitter {
       .map(function (file) {
         const filePath = path.resolve(migrationPath, file);
         if (this.options.migrations.traverseDirectories) {
-          if (fs.lstatSync(filePath).isDirectory()) {
+          if (fs.statSync(filePath).isDirectory()) {
             return this._findMigrations(filePath)
               .then((migrations) => migrations);
           }

--- a/test/Umzug/down.test.js
+++ b/test/Umzug/down.test.js
@@ -348,3 +348,20 @@ describe('down-directories', () => {
 
   downTestSuite();
 });
+
+describe('down-directories with symbolicRef', () => {
+  beforeEach(function () {
+    helper.clearTmp();
+    return helper
+      .prepareMigrations(3, { directories: [['1', '2'], ['1', '2'], ['1', '3', '4', '5']], usesSymbolicRef: true })
+      .then((migrationNames) => {
+        this.migrationNames = migrationNames;
+        this.umzug = new Umzug({
+          migrations: { path: join(__dirname, '/../tmp/1'), traverseDirectories: true },
+          storageOptions: { path: join(__dirname, '/../tmp/umzug.json') },
+        });
+      });
+  });
+
+  downTestSuite();
+});

--- a/test/Umzug/executed.test.js
+++ b/test/Umzug/executed.test.js
@@ -121,3 +121,20 @@ describe('executed-directories', () => {
 
   executedTestSuite();
 });
+
+describe('executed-directories with symbolicRef', () => {
+  beforeEach(function () {
+    helper.clearTmp();
+    return helper
+      .prepareMigrations(3, { directories: [['1', '2'], ['1', '2'], ['1', '3', '4', '5']], usesSymbolicRef: true })
+      .then((migrationNames) => {
+        this.migrationNames = migrationNames;
+        this.umzug = new Umzug({
+          migrations: { path: join(__dirname, '/../tmp/1'), traverseDirectories: true },
+          storageOptions: { path: join(__dirname, '/../tmp/umzug.json') },
+        });
+      });
+  });
+
+  executedTestSuite();
+});

--- a/test/Umzug/pending.test.js
+++ b/test/Umzug/pending.test.js
@@ -113,3 +113,20 @@ describe('pending-directories', () => {
 
   pendingTestSuite();
 });
+
+describe('pending-directories with symbolicRef', () => {
+  beforeEach(function () {
+    helper.clearTmp();
+    return helper
+      .prepareMigrations(3, { directories: [['1', '2'], ['1', '2'], ['1', '3', '4', '5']], usesSymbolicRef: true })
+      .then((migrationNames) => {
+        this.migrationNames = migrationNames;
+        this.umzug = new Umzug({
+          migrations: { path: join(__dirname, '/../tmp/1'), traverseDirectories: true },
+          storageOptions: { path: join(__dirname, '/../tmp/umzug.json') },
+        });
+      });
+  });
+
+  pendingTestSuite();
+});

--- a/test/Umzug/up.test.js
+++ b/test/Umzug/up.test.js
@@ -304,3 +304,20 @@ describe('up-directories', () => {
 
   upTestuite();
 });
+
+describe('up-directories with symbolicRef', () => {
+  beforeEach(function () {
+    helper.clearTmp();
+    return helper
+      .prepareMigrations(3, { directories: [['1', '2'], ['1', '2'], ['1', '3', '4', '5']], usesSymbolicRef: true })
+      .then((migrationNames) => {
+        this.migrationNames = migrationNames;
+        this.umzug = new Umzug({
+          migrations: { path: join(__dirname, '/../tmp/1'), traverseDirectories: true },
+          storageOptions: { path: join(__dirname, '/../tmp/umzug.json') },
+        });
+      });
+  });
+
+  upTestuite();
+});


### PR DESCRIPTION
Related to issue #33, where there are plugins with their separate migrations. This adds support for these migrations types, by symlinking them to the migrations directory and enabling the directories to be traversed